### PR TITLE
Edited makefile according to the Norme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
-NAME = minishell
-VPATH= ./src \
-./src/parser ./src/prompt ./src/signals \
- ./src/here_doc ./src/utils \
- ./src/handler_quotes \
- ./src/tokenizer \
- ./src/syntax ./src/env ./src
-CC = gcc
+NAME  = minishell
+VPATH = ./src \
+		./src/parser ./src/prompt ./src/signals \
+ 		./src/here_doc ./src/utils \
+ 		./src/handler_quotes \
+ 		./src/tokenizer \
+ 		./src/syntax ./src/env ./src
 CFLAGS = -g -std=gnu18 -Wall -Wextra -Werror
 SOURCES = main.c wait_input.c tokenizer.c setup_hook.c\
 		  heredoc.c check_unclosed.c display.c \
@@ -16,7 +15,6 @@ SOURCES = main.c wait_input.c tokenizer.c setup_hook.c\
 		  recipeOperator.c init_recipes.c lexer_strings.c init_hash.c \
 		  hash_function.c env_linked_list.c \
 		  env_utils.c ft_strjoinfree.c
-		
 
 BUILDDIR = ./build/
 LINCLUDE= ./lib/include


### PR DESCRIPTION
changes:
(-) CC = gcc
(+) CC implicitly receives cc by default On makefile why:
-> 42 Norme explicitly says we must compile with cc, so no gcc allowed. -> trying to compile with gcc was also creating the following compilation error inside my ubuntu container (where cc is just a symlink to clang-12 just like at the 42 campus):

    /usr/bin/ld: lib/libft.a(ft_ithex.o): relocation R_X86_64_32S against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIE
    /usr/bin/ld: failed to set dynamic section sizes: bad value
    collect2: error: ld returned 1 exit status
    make: *** [Makefile:45: minishell] Error 1

-> Now it is solved

	modified:   Makefile