### PR TITLE
refactoring signatures of the builtin functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ VPATH = ./src \
  		./src/tokenizer \
  		./src/syntax ./src/env ./src \
 		./src/builtins ./src/executor
-CFLAGS = -g -Wall -Wextra -Werror
+CFLAGS = -g -Wall -Wextra -Werror -fsanitize=address
 SOURCES = main.c wait_input.c tokenizer.c setup_hook.c\
 		  heredoc.c check_unclosed.c display.c \
 		  init_signal.c clear_bimatrix.c \
@@ -20,7 +20,7 @@ SOURCES = main.c wait_input.c tokenizer.c setup_hook.c\
 		  init_env.c init_statics.c \
 	
 
-BUILDDIR = ./build/
+BUILDDIR = ./objs/
 LINCLUDE= ./lib/include
 INCLUDE = ./include
 LIB = libft.a
@@ -36,7 +36,7 @@ Pur='\033[0;35m'
 Cya='\033[0;36m'
 Whi='\033[0;37m'
 
-MSGBUILD="[$(Yel)+$(RCol)]"
+MSGBUILD="[$(Gre)+$(RCol)]"
 MSGRM="[$(Red)-$(RCol)]"
 
 all: $(NAME)
@@ -47,7 +47,7 @@ $(NAME): $(OBJS)
 	@printf "$(MSGBUILD) $@: Program has been created!                                                          \n"
 
 $(BUILDDIR)%.o: %.c
-	@printf "$(MSGBUILD) $(NAME): building $@                                                                               \r"
+	@printf "$(MSGBUILD) $(NAME): building $@                                                                   \r"
 	@test -d $(BUILDDIR) || mkdir $(BUILDDIR)
 	@$(CC) $(CFLAGS) -I$(INCLUDE) -I$(LINCLUDE) -c $< -o $@
 

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -37,7 +37,6 @@
 # define ENV_NAME_SZ 1024
 # define HEAP_OVERFLOW_PROTECTION 100000
 
-typedef long long int	t_lli;
 typedef struct s_node	t_node;
 typedef struct s_data	t_databus;
 typedef t_node			*t_fn_node_apply(char *);
@@ -45,6 +44,10 @@ typedef short int		t_bool;
 typedef struct s_env	t_env;
 typedef enum e_tokens	t_tokens;
 typedef int				t_recipes(t_tokens);
+
+// aliases to longer types
+typedef long long int	t_lli;
+typedef t_databus 		t_dt;
 
 typedef enum e_tokens
 {
@@ -82,6 +85,9 @@ typedef struct s_data
 	char				*env[ENV_CONTENT_SZ];
 	t_cmds				*cmds;
 	char				*prompt;
+	char				*env_to_unset;
+	char				*new_env;
+	char				**envp;
 }						t_databus;
 
 typedef struct s_node
@@ -134,27 +140,22 @@ t_env					*ft_env_new(void);
 t_env					*ft_last_env(t_env *head);
 void					string_eat_at(char **word, char at);
 t_tokens				get_expansion(char *line);
-void					get_env_content(t_databus *data, char *content,
-							char *name);
+void					get_env_content(t_dt *d, char *content, char *name);
 char					*trim_key(char *key);
 char					*expand_dolar(char *line);
 char					*ft_strjoin_free(char *s1, char *s2);
 void					executor(t_databus *data);
-void					env_builtin(char *env[ENV_CONTENT_SZ],
-							int number_of_envs);
 char					**get_lexemes(void);
 char					**get_builtins(void);
 char					**get_expansion_lexes(void);
-void					init_env(char *env[ENV_CONTENT_SZ], char **envp,
-							t_databus *data);
-void					free_env(char *envp[ENV_CONTENT_SZ],
-							int number_of_envs);
+void					init_env(t_databus *data);
+void					free_env(t_databus *data);
 void					free_all(t_databus *data);
+void					env_builtin(t_databus *data);
 void					exit_builtin(t_databus *data);
-void					export_builtin(t_databus *data, char *new_env);
-void					unset_builtin(t_databus *data, char *env_to_unset);
-void					alt_env_builtin(char *env[ENV_CONTENT_SZ],
-							int number_of_envs);
+void					export_builtin(t_databus *data);
+void					unset_builtin(t_databus *data);
+void					alt_env_builtin(t_databus *data);
 int						is_valid_env_name(char *name_value);
 
 #endif // !

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -53,10 +53,10 @@ all: $(LIB)
 
 $(LIB): $(OBJS)
 	@ar -rcs $@ $(OBJS)
-	@printf "$(MSGBUILD) (libft): ok                                                                                                       \n"
+	@printf "$(MSGBUILD) (libft): ok                                                                      \n"
 
 $(BUILDDIR)%.o: %.c
-	@printf "$(MSGBUILD) (libft): building $@                                                                               \r"
+	@printf "$(MSGBUILD) (libft): building $@                                                             \r"
 	@test -d $(BUILDDIR) || mkdir $(BUILDDIR)
 	@$(CC) $(CFLAGS) -I./include -c $< -o $@
 

--- a/src/builtins/env_builtin.c
+++ b/src/builtins/env_builtin.c
@@ -12,32 +12,32 @@
 
 #include "minishell.h"
 
-void	env_builtin(char *env[ENV_CONTENT_SZ], int number_of_envs)
+void	env_builtin(t_databus *d)
 {
 	int	i;
 
 	i = -1;
-	while (++i < number_of_envs)
+	while (++i < d->number_of_envs)
 	{
-		if (env[i])
+		if (d->env[i])
 		{
-			ft_putstr_fd(env[i], 1);
+			ft_putstr_fd(d->env[i], 1);
 			ft_putchar_fd('\n', 1);
 		}
 	}
 }
 
-void	alt_env_builtin(char *env[ENV_CONTENT_SZ], int number_of_envs)
+void	alt_env_builtin(t_databus *data)
 {
 	int	i;
 
 	i = -1;
-	while (++i < number_of_envs)
+	while (++i < data->number_of_envs)
 	{
-		if (env[i])
+		if (data->env[i])
 		{
 			ft_putstr_fd("declare -x ", 1);
-			ft_putstr_fd(env[i], 1);
+			ft_putstr_fd(data->env[i], 1);
 			ft_putchar_fd('\n', 1);
 		}
 	}

--- a/src/builtins/exit_builtin.c
+++ b/src/builtins/exit_builtin.c
@@ -17,7 +17,7 @@ void	free_all(t_databus *data)
 	free_cmds(data->cmds);
 	free(data->cmds);
 	free(data->stream);
-	free_env(data->env, data->number_of_envs);
+	free_env(data);
 	free(data->prompt);
 	rl_clear_history();
 }

--- a/src/builtins/export_builtin.c
+++ b/src/builtins/export_builtin.c
@@ -12,8 +12,11 @@
 
 #include "minishell.h"
 
-void	export_builtin(t_databus *data, char *new_env)
+void	export_builtin(t_databus *data)
 {
+	char *new_env;
+
+	new_env = data->cmds->head->next->data;
 	if (!is_valid_env_name(new_env))
 	{
 		printf("minishell: export: `%s': not a valid identifier\n", new_env);

--- a/src/builtins/unset_builtin.c
+++ b/src/builtins/unset_builtin.c
@@ -12,12 +12,14 @@
 
 #include "minishell.h"
 
-void	unset_builtin(t_databus *data, char *env_to_unset)
+void	unset_builtin(t_databus *data)
 {
 	int	len;
+	char *env_to_unset;
 	int	i;
 
 	i = -1;
+	env_to_unset = data->cmds->head->next->data;
 	len = ft_strlen(env_to_unset);
 	if (!len)
 		return ;

--- a/src/env/init_env.c
+++ b/src/env/init_env.c
@@ -12,11 +12,13 @@
 
 #include "minishell.h"
 
-void	init_env(char *env[ENV_CONTENT_SZ], char **envp, t_databus *data)
+void	init_env(t_databus *data)
 {
 	int	i;
+	char **envp;
 
 	i = -1;
+	envp = data->envp;
 	data->number_of_envs = 0;
 	while (envp[data->number_of_envs] != NULL)
 		data->number_of_envs++;
@@ -24,19 +26,19 @@ void	init_env(char *env[ENV_CONTENT_SZ], char **envp, t_databus *data)
 	{
 		while (++i < data->number_of_envs)
 		{
-			env[i] = ft_strdup(envp[i]);
-			if (env[i] == NULL)
+			data->env[i] = ft_strdup(envp[i]);
+			if (data->env[i] == NULL)
 				break ;
 		}
 	}
 }
 
-void	free_env(char *env[ENV_CONTENT_SZ], int number_of_envs)
+void	free_env(t_databus *data)
 {
 	int	i;
 
 	i = -1;
-	while (++i < number_of_envs)
-		if (env[i])
-			free(env[i]);
+	while (++i < data->number_of_envs)
+		if (data->env[i])
+			free(data->env[i]);
 }

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -14,17 +14,20 @@
 
 void	executor(t_databus *data)
 {
-	if (!ft_strncmp(data->stream, "exit", 5))
+	char *cmd;
+	t_node *node;
+
+	node = data->cmds->head;
+	cmd = node->data;
+	if (!ft_strncmp(cmd, "exit", 5))
 		exit_builtin(data);
-	else if (!ft_strncmp(data->stream, "env", 4))
-		env_builtin(data->env, data->number_of_envs);
-	else if (!ft_strncmp(data->stream, "export ", 7))
-		export_builtin(data, &data->stream[7]);
-	else if (!ft_strncmp(data->stream, "export", 7))
-		alt_env_builtin(data->env, data->number_of_envs);
-	else if (!ft_strncmp(data->stream, "declare -x ", 11))
-		export_builtin(data, &data->stream[11]);
-	else if (!ft_strncmp(data->stream, "unset ", 6))
-		unset_builtin(data, &data->stream[6]);
+	else if (!ft_strncmp(cmd, "env", 4))
+		env_builtin(data);
+	else if (!ft_strncmp(cmd, "export", 7) && node->next)
+		export_builtin(data);
+	else if (!ft_strncmp(cmd, "export", 7) && !node->next)
+		alt_env_builtin(data);
+	else if (!ft_strncmp(cmd, "unset", 6))
+		unset_builtin(data);
 	return ;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -18,9 +18,10 @@ int	main(int argc, char *argv[], char *envp[])
 
 	(void)argc;
 	(void)argv;
+	data.envp = envp;
 	init_signal();
 	main_setup_hook(&data);
-	init_env(data.env, envp, &data);
+	init_env(&data);
 	repl(&data);
 	return (0);
 }


### PR DESCRIPTION
now all of them are in the format ---->
    void function(t_databus *data);

	modified:   Makefile
	modified:   include/minishell.h
	modified:   lib/Makefile
	modified:   src/builtins/env_builtin.c
	modified:   src/builtins/exit_builtin.c
	modified:   src/builtins/export_builtin.c
	modified:   src/builtins/unset_builtin.c
	modified:   src/env/init_env.c
	modified:   src/executor/executor.c
	modified:   src/main.c