### PR TITLE
there was a segfault in some cases

### DIFF
--- a/src/builtins/unset_builtin.c
+++ b/src/builtins/unset_builtin.c
@@ -13,7 +13,7 @@
 #include "minishell.h"
 
 static int			whole_prefix_matched(t_databus *data, int i, int len);
-static int			getindex_of_env_to_unset(t_databus *data, char *env, int n);
+static int			getindex_of_env_to_unset(t_databus *data, char *env);
 
 void	unset_builtin(t_databus *data)
 {
@@ -22,34 +22,31 @@ void	unset_builtin(t_databus *data)
 	t_node	*list;
 
 	nb = data->number_of_envs;
-	list = data->cmds->head->next;
-	while (list)
+	list = data->cmds->head;
+	while (list->next)
 	{
-		if (is_being_initialized(list->data))
-		{
-			list = list->next;
+		list = list->next;
+		i = getindex_of_env_to_unset(data, list->data);
+		if (is_being_initialized(list->data) || T_INVALID == i)
 			continue ;
-		}
-		i = getindex_of_env_to_unset(data, list->data, nb);
-		if (-1 == i)
-			return ;
 		while (i < nb)
 		{
 			ft_memmove(&data->env[i], &data->env[i + 1], STR_LIMIT);
 			i++;
 		}
-		list = list->next;
 		data->number_of_envs--;
 	}
 }
 
-static int	getindex_of_env_to_unset(t_databus *data, char *to_unset, int nb)
+static int	getindex_of_env_to_unset(t_databus *data, char *to_unset)
 {
 	int	i;
 	int	len;
+	int	nb;
 
 	i = -1;
 	len = ft_strlen(to_unset);
+	nb = data->number_of_envs;
 	if (!len)
 		return (-1);
 	while (++i < nb)


### PR DESCRIPTION
Cases where one or more of the unset arguments (when multiple) weren't valid

	modified:   src/builtins/unset_builtin.c