### PR TITLE
Remove quotes

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -212,5 +212,6 @@ char						*expand_everything_on_str(char *str);
 int							whole_prefix_matched(int i, int len);
 char						*handle_frees(char *tmp, char *new_line, char *line,
 								int dollar);
+char						*remove_quotes(char *list_str);
 
 #endif

--- a/src/builtins/cd_builtin.c
+++ b/src/builtins/cd_builtin.c
@@ -22,6 +22,8 @@ void	cd_builtin(t_node *current)
 	char	cwd[STR_LIMIT];
 
 	if (current->next)
+		current = current->next;
+	if (current->next)
 		path_address = &current->next->str;
 	else
 	{

--- a/src/builtins/echo_builtin.c
+++ b/src/builtins/echo_builtin.c
@@ -17,6 +17,8 @@ void	echo_builtin(t_node *current)
 	int	n_flag;
 
 	n_flag = 0;
+	if (current->next)
+		current = current->next;
 	while (current->next && !ft_strcmp("-n", current->next->str))
 	{
 		n_flag = 1;

--- a/src/builtins/exit_builtin.c
+++ b/src/builtins/exit_builtin.c
@@ -24,8 +24,8 @@ void	exit_builtin(t_node *current)
 	(void)current;
 	data = getter_data();
 	exit_argument = NULL;
-	if (data->cmds->head->next)
-		exit_argument = data->cmds->head->next->str;
+	if (current->next && current->next->next)
+		exit_argument = current->next->next->str;
 	data->exit_status = 0;
 	if (!exit_argument)
 		free_and_exit(data, NULL);
@@ -85,12 +85,19 @@ int	has_too_many_args(t_databus *data)
 	head = data->cmds->head;
 	too_many_args = NULL;
 	if (head)
-		arg1 = head->next;
-	if (arg1)
-		too_many_args = arg1->next;
-	if (too_many_args)
 	{
-		return (TRUE);
+		arg1 = head->next;
+		if (arg1->token != T_WORD)
+			arg1 = arg1->next;
 	}
+	if (arg1)
+	{
+		arg1 = head->next;
+		if (arg1->token != T_WORD)
+			arg1 = arg1->next;
+		too_many_args = arg1->next;
+	}
+	if (too_many_args)
+		return (TRUE);
 	return (FALSE);
 }

--- a/src/builtins/export_builtin.c
+++ b/src/builtins/export_builtin.c
@@ -25,9 +25,12 @@ void	export_builtin(t_node *current)
 	if (!is_valid_syntax(current))
 		return ;
 	data = getter_data();
+	current = current->next;
 	while (current->next)
 	{
 		current = current->next;
+		if (current->token != T_WORD)
+			current = current->next;
 		new_env = current->str;
 		len = ft_strlen(new_env) + 1;
 		if (!is_valid_env_name_err(new_env))
@@ -57,7 +60,6 @@ static int	is_valid_env_name_err(char *env)
 		if (!ft_isalnum(*env) && *env != '_')
 		{
 			ft_putstr_fd("minishell: export:", 1);
-			ft_putstr_fd(getter_data()->new_env, 1);
 			ft_putstr_fd(" not a valid identifier\n", 2);
 			getter_data()->exit_status = 1;
 			return (0);

--- a/src/builtins/unset_builtin.c
+++ b/src/builtins/unset_builtin.c
@@ -22,22 +22,21 @@ void	unset_builtin(t_node *current)
 	t_databus	*data;
 
 	data = getter_data();
-	data->exit_status = 0;
 	nb = data->number_of_envs;
-	if (!is_valid_syntax(current))
+	if (!is_valid_syntax(current) || !current->next)
 		return ;
+	current = current->next;
 	while (current->next)
 	{
 		current = current->next;
+		if (current->token != T_WORD)
+			current = current->next;
 		new_env = current->str;
-		i = getindex_of_env_to_unset(data, new_env);
-		if (is_being_initialized(new_env) || (T_INVALID == i))
+		i = getindex_of_env_to_unset(data, new_env) - 1;
+		if (is_being_initialized(new_env) || (T_INVALID == i + 1))
 			continue ;
-		while (i < nb)
-		{
+		while (++i < nb)
 			ft_memmove(&data->env[i], &data->env[i + 1], STR_LIMIT);
-			i++;
-		}
 		data->number_of_envs--;
 	}
 }

--- a/src/expansions/expansion_utils.c
+++ b/src/expansions/expansion_utils.c
@@ -6,7 +6,7 @@
 /*   By: vcedraz- <vcedraz-@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/26 22:06:59 by vcedraz-          #+#    #+#             */
-/*   Updated: 2023/06/26 22:14:06 by vcedraz-         ###   ########.fr       */
+/*   Updated: 2023/06/30 22:59:46 by vcedraz-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,4 +42,56 @@ char	*handle_frees(char *tmp, char *new_line, char *line, int has_dollar)
 	}
 	free(line);
 	return (new_line);
+}
+
+int	count_quotes(char *list_str)
+{
+	int	i;
+	int	count;
+
+	i = 0;
+	count = 0;
+	while (list_str[i])
+	{
+		if (list_str[i] == '"')
+			count++;
+		i++;
+	}
+	return (count);
+}
+
+static void	copy_str(char *list_str, char *new_str)
+{
+	if (*list_str == '\'')
+	{
+		while (*list_str)
+		{
+			if (*list_str != '\'')
+				*new_str++ = *list_str;
+			list_str++;
+		}
+	}
+	else
+	{
+		while (*list_str)
+		{
+			if (*list_str != '"')
+				*new_str++ = *list_str;
+			list_str++;
+		}
+	}
+}
+
+char	*remove_quotes(char *list_str)
+{
+	int		len;
+	int		count;
+	char	*new_str;
+
+	count = count_quotes(list_str);
+	len = ft_strlen(list_str) - count;
+	new_str = ft_calloc(sizeof(char), (len + 1));
+	copy_str(list_str, new_str);
+	free(list_str);
+	return (new_str);
 }

--- a/src/expansions/handle_expansions.c
+++ b/src/expansions/handle_expansions.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   expand_dollar_env.c                                :+:      :+:    :+:   */
+/*   handle_expansions.c                                :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: vcedraz- <vcedraz-@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/26 20:58:10 by vcedraz-          #+#    #+#             */
-/*   Updated: 2023/06/26 22:14:51 by vcedraz-         ###   ########.fr       */
+/*   Updated: 2023/06/30 23:02:03 by vcedraz-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,8 @@ void	handle_expansions(void)
 	{
 		if (list->str && *list->str != '\'')
 			list->str = expand_dollars(list->str);
+		if (list->str && (*list->str == '"' || *list->str == '\''))
+			list->str = remove_quotes(list->str);
 		list = list->next;
 	}
 }

--- a/src/expansions/retokenize.c
+++ b/src/expansions/retokenize.c
@@ -12,7 +12,7 @@
 
 #include "minishell.h"
 
-static void		walk_on_the_list(t_node **lst, int *joined);
+static void		walk_on_the_list(t_node **lst);
 static char		*join_many_strs(t_node **lst);
 static t_node	*apply_join_many_strs(t_databus *data);
 
@@ -49,23 +49,21 @@ static t_node	*apply_join_many_strs(t_databus *data)
 static char	*join_many_strs(t_node **lst)
 {
 	char	*result;
-	int		joined;
 
 	if (!*lst || !(*lst)->str)
 		return (NULL);
 	result = ft_strdup((*lst)->str);
-	if (!(*lst)->next || !(*lst)->next->str)
+	if (!(*lst)->next || !(*lst)->next->str || *(*lst)->str == ' ')
 		return (result);
 	while (1)
 	{
 		if (!(*lst) || (*lst)->token != T_WORD)
 			break ;
-		else
+		else if ((*lst)->next->token == T_WORD)
 		{
 			result = strjoinfree_s1(result, (*lst)->next->str);
-			joined = 1;
+			walk_on_the_list(lst);
 		}
-		walk_on_the_list(lst, &joined);
 		if (!(*lst)->next || (*lst)->next->token != T_WORD)
 			break ;
 	}
@@ -73,14 +71,8 @@ static char	*join_many_strs(t_node **lst)
 }
 
 // if (joined) we have to walk two times, else only once
-static void	walk_on_the_list(t_node **lst, int *joined)
+static void	walk_on_the_list(t_node **lst)
 {
-	if (*joined)
-	{
-		if ((*lst)->next)
-			*lst = (*lst)->next;
-		(*joined) = 0;
-	}
-	else
+	if ((*lst)->next)
 		*lst = (*lst)->next;
 }

--- a/src/prompt/wait_input.c
+++ b/src/prompt/wait_input.c
@@ -30,14 +30,11 @@ static inline void	if_stream_not_null(t_databus *data)
 	if (data->stream)
 	{
 		tokenizer();
-		print_data(0);
 		add_history(data->stream);
 		if (is_valid_syntax(data->cmds->head))
 		{
 			handle_expansions();
-			print_data(0);
 			retokenize();
-			print_data(0);
 			executor(data);
 		}
 		free_cmds(data->cmds);

--- a/src/prompt/wait_input.c
+++ b/src/prompt/wait_input.c
@@ -30,11 +30,14 @@ static inline void	if_stream_not_null(t_databus *data)
 	if (data->stream)
 	{
 		tokenizer();
+		print_data(0);
 		add_history(data->stream);
 		if (is_valid_syntax(data->cmds->head))
 		{
 			handle_expansions();
+			print_data(0);
 			retokenize();
+			print_data(0);
 			executor(data);
 		}
 		free_cmds(data->cmds);

--- a/src/utils/print_data.c
+++ b/src/utils/print_data.c
@@ -32,9 +32,9 @@ void	print_data(int env)
 		printf(RED "    cmds->head:" RESET " %p\n", tmp);
 		printf(RED "    cmds->head->token:" RESET " %d\n", tmp->token);
 		if (*tmp->str == ' ')
-			printf(RED "    cmds->head->str:" RESET " %s\n", "<space>");
+			printf(RED "    cmds->head->str:" RESET " \"%s\"\n", "<space>");
 		else
-			printf(RED "    cmds->head->str:" RESET " %s\n", tmp->str);
+			printf(RED "    cmds->head->str:" RESET " \"%s\"\n", tmp->str);
 		tmp = tmp->next;
 	}
 	printf(RED "cmds: "RESET"%p\n", tmp);


### PR DESCRIPTION
Passando em todos os testes de builtins do tester!

Esse branch implementou a remocao correta das aspas depois de ter expandido as variaveis de ambiente e retokenizado toda a data->cmds->head.

Alem disso, descobri um bug na retokenizacao e consertei: em vez de inicializar um nodo com "echo" e o proximo  com "<space>" e proximo com  "hello" e depois "<space>" e depois "world" eu estava iniciando um nodo com "echo " e o proximo com "hello " e  o outro com "world".

Ou seja, so dava certo nos testes de echo e em alguns testes simples de export, mas o tester revelou varios comportamentos indefinidos por causa desse erro e depois de consertar ele passei em todos os testes.